### PR TITLE
Make sure GH deployment env is deleted and build is not run on PR close

### DIFF
--- a/.github/workflows/deploy-to-azure-app-service.yml
+++ b/.github/workflows/deploy-to-azure-app-service.yml
@@ -16,6 +16,7 @@ permissions:
 
 jobs:
   build:
+    if: github.event.action != 'closed'
     runs-on: ubuntu-latest
 
     steps:
@@ -211,9 +212,7 @@ jobs:
         uses: octokit/request-action@v2.x
         id: delete_github-deploy-env
         with:
-          route: DELETE /repos/{owner}/{repo}/environments/preview-pr-${{ github.event.pull_request.number }}
-          owner: SmashGrade
-          repo: SmashGrade-App
+          route: DELETE /repos/SmashGrade/SmashGrade-App/environments/preview-pr-${{ github.event.pull_request.number }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Desc:
- Make sure deployment envs are deleted when PR is closed/merged
- Do not run build on PR close/merge
